### PR TITLE
fix(init): initial changes

### DIFF
--- a/apps/native/app/(drawer)/(tabs)/_layout.tsx
+++ b/apps/native/app/(drawer)/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
-import { Tabs } from "expo-router";
+import { Tabs, type } from "expo-router";
 import { useThemeColor } from "heroui-native";
 
 export default function TabLayout() {


### PR DESCRIPTION
### TL;DR

Import `type` from expo-router in the tabs layout file.

### What changed?

Added the `type` import from expo-router alongside the existing Tabs import in the tabs layout file. The import statement now reads `import { Tabs, type } from "expo-router";` instead of just importing `Tabs`.

### How to test?

1. Run the native app
2. Verify that the tab navigation works as expected
3. Check that there are no TypeScript errors related to the expo-router imports

### Why make this change?

This change likely supports TypeScript type checking for expo-router components. Adding the `type` import allows for proper type definitions when working with the router, improving code quality and developer experience by enabling better type safety and autocompletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code optimization with no user-facing impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->