### PR TITLE
Parse streamed AI plan JSON into readable text (native)

### DIFF
--- a/apps/native/app/test/ai-stream.tsx
+++ b/apps/native/app/test/ai-stream.tsx
@@ -457,6 +457,11 @@ export default function PlannerAiStreamTest({ planId, conversationId }: PlannerA
       updateStreamingMessage(formattedContent);
 
       if (conversationId && streamingMessageId.current) {
+        persistAssistantContentThrottled.flush(
+          conversationId,
+          streamingMessageId.current,
+          formattedContent,
+        );
         updateMessage(conversationId, streamingMessageId.current, {
           status: "final",
           content: formattedContent,


### PR DESCRIPTION
### Motivation
- The native chat UI receives AI responses as raw or streamed JSON and users need a readable, human-friendly plan view instead of raw JSON blobs. 
- The streaming SSE output can include fenced JSON blocks or inline JSON fragments that must be extracted and normalized before display. 
- Seeded plan content loaded from storage should also be rendered in the same readable format for consistency.

### Description
- Added JSON extraction and parsing helpers: `extractJsonPayload`, `parseStructuredResponse`, and `formatReadablePlan` to detect fenced JSON or inline JSON and parse it into `StructuredAIResponse` using types from `@monthly-zen/types`. 
- Implemented formatting helpers `formatStructuredResponse`, `formatWeekSection`, and `formatTaskLine` (with `DAY_ORDER`) to convert structured weekly breakdowns and tasks into readable plaintext. 
- Integrated formatting into the streaming flow by accumulating raw stream text in `streamingRawText`, formatting it in `finalizeStream`, and persisting the formatted content via `updateMessage`/`updateConversation`. 
- Applied the same formatting to seeded/loaded plan responses (`plan.rawAiResponse` / `plan.aiResponseRaw`) so stored plans render readable text in the native test screen.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69770d498c9c8321aa17daa6de55665c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-generated plans now render as human-readable weekly/daily schedules with optional focus, difficulty, time, and scheduling reasons.
  * Initial assistant responses are presented in the same formatted style instead of raw payloads.

* **Bug Fixes / Improvements**
  * Streaming responses deliver smoother incremental updates and reliably finalize into the formatted plan.

* **Chores**
  * Throttling for streaming updates now supports immediate flush and cancel for more consistent content persistence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->