### PR TITLE
Add per-conversation streaming monitor settings

### DIFF
--- a/apps/native/app/(tabs)/index.tsx
+++ b/apps/native/app/(tabs)/index.tsx
@@ -40,6 +40,8 @@ const styles = StyleSheet.create({
   },
 });
 
+let hasAutoOpenedOnce = false;
+
 export default function Home() {
   const router = useRouter();
   const rootNavigationState = useRootNavigationState();
@@ -74,11 +76,12 @@ export default function Home() {
   );
 
   useEffect(() => {
-    if (didAutoOpen.current) return;
+    if (didAutoOpen.current || hasAutoOpenedOnce) return;
     if (!rootNavigationState?.key) return;
     const lastId = getLastConversationId();
     if (!lastId) {
       didAutoOpen.current = true;
+      hasAutoOpenedOnce = true;
       return;
     }
 
@@ -86,6 +89,7 @@ export default function Home() {
     if (exists) {
       router.replace({ pathname: "/chat", params: { conversationId: lastId } });
       didAutoOpen.current = true;
+      hasAutoOpenedOnce = true;
     }
   }, [router, rootNavigationState?.key, conversations]);
 

--- a/apps/native/app/(tabs)/index.tsx
+++ b/apps/native/app/(tabs)/index.tsx
@@ -18,14 +18,15 @@ import {
   TodaysTasksCard,
 } from "@/components/home";
 import { useSemanticColors } from "@/utils/theme";
-import {
-  Conversation,
-  createConversation,
-  deleteConversation,
-  getLastConversationId,
-  listConversations,
-  setLastConversationId,
-} from "@/storage/chatStore";
+import { getLastConversationId, setLastConversationId } from "@/storage/chatStore";
+import { authClient } from "@/lib/auth-client";
+
+type Conversation = {
+  id: string;
+  title: string | null;
+  lastMessagePreview: string | null;
+  updatedAt: string;
+};
 
 const styles = StyleSheet.create({
   backgroundGlow: {
@@ -47,11 +48,24 @@ export default function Home() {
   const lastConversationRef = useRef<string | null>(null);
   const didAutoOpen = useRef(false);
 
-  const loadConversations = useCallback(() => {
-    const items = listConversations();
-    setConversations(items);
+  const serverUrl = process.env.EXPO_PUBLIC_SERVER_URL;
+
+  const loadConversations = useCallback(async () => {
+    if (!serverUrl) return;
+    const cookie = authClient.getCookie();
+    const headers = cookie ? { Cookie: cookie } : undefined;
+
+    const res = await fetch(`${serverUrl}/api/conversations`, {
+      headers,
+      credentials: "include",
+    });
+
+    if (!res.ok) return;
+    const data = (await res.json()) as { conversations?: Conversation[] };
+    if (!Array.isArray(data.conversations)) return;
+    setConversations(data.conversations);
     lastConversationRef.current = getLastConversationId();
-  }, []);
+  }, [serverUrl]);
 
   useFocusEffect(
     useCallback(() => {
@@ -68,12 +82,12 @@ export default function Home() {
       return;
     }
 
-    const exists = listConversations().some((conversation) => conversation.id === lastId);
+    const exists = conversations.some((conversation) => conversation.id === lastId);
     if (exists) {
       router.replace({ pathname: "/chat", params: { conversationId: lastId } });
       didAutoOpen.current = true;
     }
-  }, [router, rootNavigationState?.key]);
+  }, [router, rootNavigationState?.key, conversations]);
 
   const backgroundGlow = useMemo(
     () => (
@@ -90,14 +104,30 @@ export default function Home() {
 
   const handleNewChat = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    const conversation = createConversation("Planner Chat");
-    setLastConversationId(conversation.id);
-    lastConversationRef.current = conversation.id;
-    loadConversations();
-    router.push({
-      pathname: "/chat",
-      params: { conversationId: conversation.id },
-    });
+    if (!serverUrl) return;
+
+    const cookie = authClient.getCookie();
+    const headers = cookie ? { Cookie: cookie } : undefined;
+
+    const create = async () => {
+      const res = await fetch(`${serverUrl}/api/conversations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...(headers ?? {}) },
+        credentials: "include",
+        body: JSON.stringify({ title: "Planner Chat" }),
+      });
+
+      if (!res.ok) return;
+      const data = (await res.json()) as { id?: string };
+      if (!data.id) return;
+
+      setLastConversationId(data.id);
+      lastConversationRef.current = data.id;
+      await loadConversations();
+      router.push({ pathname: "/chat", params: { conversationId: data.id } });
+    };
+
+    void create();
   };
 
   const openConversation = (conversationId: string) => {
@@ -108,11 +138,23 @@ export default function Home() {
 
   const handleDelete = (conversationId: string) => {
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
-    deleteConversation(conversationId);
-    loadConversations();
+    if (!serverUrl) return;
+    const cookie = authClient.getCookie();
+    const headers = cookie ? { Cookie: cookie } : undefined;
+
+    const remove = async () => {
+      await fetch(`${serverUrl}/api/conversations/${conversationId}`, {
+        method: "DELETE",
+        headers,
+        credentials: "include",
+      }).catch(() => {});
+      await loadConversations();
+    };
+
+    void remove();
   };
 
-  const formatDate = (timestamp: number) => {
+  const formatDate = (timestamp: string) => {
     return new Date(timestamp).toLocaleDateString(undefined, {
       month: "short",
       day: "numeric",

--- a/apps/native/app/(tabs)/profile/[id].tsx
+++ b/apps/native/app/(tabs)/profile/[id].tsx
@@ -72,7 +72,7 @@ export default function ProfileDynamicScreen() {
   const [taskComplexity, setTaskComplexity] = useState<"Simple" | "Balanced" | "Ambitious">(
     "Balanced",
   );
-  const [focusAreas, setFocusAreas] = useState("");
+  const [defaultFocusArea, setDefaultFocusArea] = useState("");
   const [weekendPreference, setWeekendPreference] = useState<"Work" | "Rest" | "Mixed">("Mixed");
   const [preferredTaskDuration, setPreferredTaskDuration] = useState(45);
 
@@ -87,7 +87,7 @@ export default function ProfileDynamicScreen() {
   useEffect(() => {
     if (preferences) {
       setTaskComplexity(preferences.taskComplexity || "Balanced");
-      setFocusAreas(preferences.focusAreas || "");
+      setDefaultFocusArea(preferences.defaultFocusArea || "");
       setWeekendPreference(preferences.weekendPreference || "Mixed");
       setPreferredTaskDuration(preferences.preferredTaskDuration || 45);
       setCoachName(preferences.coachName || "Coach");
@@ -121,13 +121,13 @@ export default function ProfileDynamicScreen() {
       updatePreferences.mutate(
         {
           taskComplexity,
-          focusAreas,
           weekendPreference,
           preferredTaskDuration,
           coachName,
           coachTone,
           workingHoursStart,
           workingHoursEnd,
+          defaultFocusArea,
           fixedCommitmentsJson: { commitments },
         },
         {
@@ -148,7 +148,7 @@ export default function ProfileDynamicScreen() {
     isEditPreferences,
     profileName,
     taskComplexity,
-    focusAreas,
+    defaultFocusArea,
     weekendPreference,
     preferredTaskDuration,
     coachName,
@@ -430,13 +430,13 @@ export default function ProfileDynamicScreen() {
                 <Section icon={Compass01Icon} title="Operating Habitat">
                   <View className="bg-surface rounded-[24px] border border-border/50 px-5 py-5">
                     <Text className="text-[10px] font-sans-bold text-muted-foreground uppercase tracking-widest mb-2 ml-1">
-                      Focus Sectors
+                      Default Focus Area
                     </Text>
                     <TextInput
                       className="text-foreground text-base font-sans-medium"
-                      value={focusAreas}
-                      onChangeText={setFocusAreas}
-                      placeholder="e.g. Health, Finance, Deep Work"
+                      value={defaultFocusArea}
+                      onChangeText={setDefaultFocusArea}
+                      placeholder="e.g. Health"
                       placeholderTextColor="var(--muted-foreground)/50"
                     />
                   </View>

--- a/apps/native/app/chat.tsx
+++ b/apps/native/app/chat.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import PlannerAiStreamTest from "./test/ai-stream";
+import { authClient } from "@/lib/auth-client";
 
 export default function Chat() {
   const router = useRouter();
@@ -22,11 +23,14 @@ export default function Chat() {
     const serverUrl = process.env.EXPO_PUBLIC_SERVER_URL;
     if (!serverUrl) return;
 
+    const cookie = authClient.getCookie();
+    const authHeaders: Record<string, string> = cookie ? { Cookie: cookie } : {};
+
     const ensure = async () => {
       if (conversationId) {
         await fetch(`${serverUrl}/api/conversations`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", ...authHeaders },
           credentials: "include",
           body: JSON.stringify({ id: conversationId, title: "Planner Chat" }),
         }).catch(() => {});
@@ -37,7 +41,7 @@ export default function Chat() {
 
       const res = await fetch(`${serverUrl}/api/conversations`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders },
         credentials: "include",
         body: JSON.stringify({ title: "Planner Chat" }),
       });

--- a/apps/native/app/draft/[draftKey].tsx
+++ b/apps/native/app/draft/[draftKey].tsx
@@ -1,0 +1,79 @@
+import { ScrollView, Text, TouchableOpacity, View } from "react-native";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+
+import { Container } from "@/components/ui/container";
+import { orpc } from "@/utils/orpc";
+
+export default function DraftReviewScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams();
+  const draftKeyParam = Array.isArray(params.draftKey) ? params.draftKey[0] : params.draftKey;
+  const draftKey = typeof draftKeyParam === "string" ? draftKeyParam : "";
+
+  const draftQuery = useQuery({
+    ...orpc.plan.getDraft.queryOptions({ input: { draftKey } }),
+    enabled: draftKey.length > 0,
+  });
+
+  const raw = draftQuery.data?.success ? (draftQuery.data.data as any) : null;
+  const planData = raw?.planData ?? raw?.aiResponseRaw;
+  const content =
+    planData && typeof planData === "object" && typeof planData.content === "string"
+      ? planData.content
+      : typeof planData === "string"
+        ? planData
+        : planData
+          ? JSON.stringify(planData, null, 2)
+          : "";
+
+  return (
+    <Container className="bg-background" withScroll={false}>
+      <Stack.Screen options={{ title: "Review Draft" }} />
+
+      <View className="flex-row items-center justify-between px-6 pt-6 pb-3">
+        <TouchableOpacity
+          onPress={() => router.back()}
+          className="px-4 py-2 rounded-full bg-surface border border-border/40"
+        >
+          <Text className="text-[10px] font-sans-bold uppercase tracking-[2px] text-muted-foreground">
+            Back
+          </Text>
+        </TouchableOpacity>
+
+        <View className="px-4 py-2 rounded-full bg-accent/10 border border-accent/20">
+          <Text className="text-[10px] font-sans-bold uppercase tracking-[2px] text-accent">
+            Draft
+          </Text>
+        </View>
+      </View>
+
+      <ScrollView className="flex-1 px-6" contentContainerStyle={{ paddingBottom: 28 }}>
+        {draftQuery.isLoading ? (
+          <Text className="text-sm font-sans text-muted-foreground">Loading…</Text>
+        ) : draftQuery.data && !draftQuery.data.success ? (
+          <Text className="text-sm font-sans text-danger">
+            {draftQuery.data.error || "Draft not found"}
+          </Text>
+        ) : (
+          <View className="rounded-[24px] border border-border/50 bg-surface/60 p-5">
+            <Text className="text-[10px] font-sans-bold uppercase tracking-[3px] text-muted-foreground">
+              Latest Assistant Response
+            </Text>
+            <Text className="text-sm font-sans text-foreground mt-3 leading-6">{content}</Text>
+          </View>
+        )}
+      </ScrollView>
+
+      <View className="px-6 pb-6">
+        <View className="rounded-[24px] border border-border/40 bg-surface/40 p-5">
+          <Text className="text-sm font-sans-semibold text-foreground">Next step</Text>
+          <Text className="text-[12px] font-sans text-muted-foreground mt-2 leading-5">
+            When you’re happy with this draft, we’ll add a Confirm action that parses it into a
+            structured plan and generates tasks.
+          </Text>
+        </View>
+      </View>
+    </Container>
+  );
+}

--- a/apps/native/app/onboarding/generating.tsx
+++ b/apps/native/app/onboarding/generating.tsx
@@ -79,7 +79,7 @@ export default function GeneratingScreen() {
   const [isComplete, setIsComplete] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [jobId, setJobId] = useState<number | null>(null);
-  const [planId, setPlanId] = useState<number | null>(null);
+  const [conversationId, setConversationId] = useState<string | null>(null);
   const hasNotified = useRef(false);
 
   const sampleTasks = [
@@ -202,9 +202,9 @@ export default function GeneratingScreen() {
     }
 
     if (status === "completed") {
-      const nextPlanId = statusQuery.data?.data?.planId ?? null;
-      if (nextPlanId) {
-        setPlanId(nextPlanId);
+      const nextConversationId = statusQuery.data?.data?.conversationId ?? null;
+      if (nextConversationId) {
+        setConversationId(nextConversationId);
       }
       setIsComplete(true);
     }
@@ -238,8 +238,8 @@ export default function GeneratingScreen() {
 
   const handleContinue = async () => {
     await completeOnboarding();
-    if (planId) {
-      router.replace({ pathname: "/chat", params: { planId: String(planId) } });
+    if (conversationId) {
+      router.replace({ pathname: "/chat", params: { conversationId } });
       return;
     }
     router.replace("/chat");

--- a/apps/native/app/onboarding/generating.tsx
+++ b/apps/native/app/onboarding/generating.tsx
@@ -133,6 +133,7 @@ export default function GeneratingScreen() {
           taskComplexity,
           weekendPreference,
           fixedCommitmentsJson: parsedCommitments,
+          resolutionsJson: { resolutions: parsedResolutions },
         });
 
         startGenerationMutation.mutate({

--- a/apps/native/app/onboarding/generating.tsx
+++ b/apps/native/app/onboarding/generating.tsx
@@ -95,7 +95,7 @@ export default function GeneratingScreen() {
   const startGenerationMutation = useMutation(
     orpc.plan.startFirstGeneration.mutationOptions({
       onSuccess: (result) => {
-        if (result.success) {
+        if (result.success && typeof result.jobId === "number") {
           setJobId(result.jobId);
         } else {
           setError(result.error || "Failed to start generation");
@@ -109,8 +109,8 @@ export default function GeneratingScreen() {
   );
 
   const statusQuery = useQuery({
-    ...orpc.plan.getGenerationStatus.queryOptions({ jobId: jobId ?? 0 }),
-    enabled: jobId !== null,
+    ...orpc.plan.getGenerationStatus.queryOptions({ input: { jobId: jobId ?? 1 } }),
+    enabled: typeof jobId === "number" && jobId > 0,
     refetchInterval: (query) => {
       const status = query.state.data?.data?.status;
       if (!status || status === "completed" || status === "failed") {
@@ -132,8 +132,6 @@ export default function GeneratingScreen() {
           coachTone,
           taskComplexity,
           weekendPreference,
-          focusAreas,
-          resolutionsJson: { resolutions: parsedResolutions },
           fixedCommitmentsJson: parsedCommitments,
         });
 
@@ -181,6 +179,8 @@ export default function GeneratingScreen() {
     Notifications.setNotificationHandler({
       handleNotification: async () => ({
         shouldShowAlert: true,
+        shouldShowBanner: true,
+        shouldShowList: true,
         shouldPlaySound: true,
         shouldSetBadge: false,
       }),
@@ -215,7 +215,8 @@ export default function GeneratingScreen() {
 
     hasNotified.current = true;
     toast.show({
-      title: "Your plan is ready",
+      variant: "success",
+      label: "Your plan is ready",
       description: "Open the plan chat to refine or tweak it.",
     });
 

--- a/apps/native/app/sign-in.tsx
+++ b/apps/native/app/sign-in.tsx
@@ -6,7 +6,6 @@ import {
   ScrollView,
   Alert,
   ActivityIndicator,
-  Platform,
   Pressable,
   TextInput,
   Image,

--- a/apps/native/app/sign-up.tsx
+++ b/apps/native/app/sign-up.tsx
@@ -91,10 +91,7 @@ export default function SignUpScreen() {
 
   return (
     <Container className="bg-background" withScroll={false}>
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
-        className="flex-1"
-      >
+      <KeyboardAvoidingView behavior="height" style={{ flex: 1 }}>
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1, paddingBottom: 60 }}

--- a/apps/native/app/test/ai-stream.tsx
+++ b/apps/native/app/test/ai-stream.tsx
@@ -19,6 +19,7 @@ import EventSource from "react-native-sse";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { orpc } from "@/utils/orpc";
 import { useToast } from "heroui-native";
+import { authClient } from "@/lib/auth-client";
 
 const PROMPTS = [
   "Build a 30-day plan",
@@ -89,7 +90,11 @@ export default function PlannerAiStreamTest({ planId, conversationId }: PlannerA
   const loadConversationMessages = async () => {
     if (!conversationId || !serverUrl) return;
 
+    const cookie = authClient.getCookie();
+    const headers = cookie ? { Cookie: cookie } : undefined;
+
     const res = await fetch(`${serverUrl}/api/conversations/${conversationId}/messages`, {
+      headers,
       credentials: "include",
     });
 
@@ -256,11 +261,14 @@ export default function PlannerAiStreamTest({ planId, conversationId }: PlannerA
 
     const payload = JSON.stringify({ message: userMessage.content });
 
+    const cookie = authClient.getCookie();
+
     const eventSource = new EventSource(`${serverUrl}/api/conversations/${conversationId}/stream`, {
       method: "POST",
       headers: {
         Accept: "text/event-stream",
         "Content-Type": "application/json",
+        ...(cookie ? { Cookie: cookie } : {}),
       },
       body: payload,
       pollingInterval: 0,
@@ -341,7 +349,7 @@ export default function PlannerAiStreamTest({ planId, conversationId }: PlannerA
           {backgroundGlow}
           <View className="px-6 pt-10 pb-3 flex-row items-center gap-x-4">
             <TouchableOpacity
-              onPress={() => router.back()}
+              onPress={() => router.push("/(tabs)")}
               className="w-10 h-10 rounded-2xl bg-surface border border-border/50 items-center justify-center"
             >
               <HugeiconsIcon icon={ArrowLeft01Icon} size={18} color="var(--foreground)" />

--- a/apps/native/assets/response.txt
+++ b/apps/native/assets/response.txt
@@ -1,0 +1,283 @@
+```json
+{
+  "monthly_summary": "Welcome to your ambitious January 2026 Monthly Zen plan, starting from the 25th! This plan is designed to integrate your new journaling habit with core yearly resolutions across health, learning, finance, and personal growth. With an 'Ambitious' complexity setting, expect deep work sessions focused on starting your Go microservices journey, establishing a robust push-up schedule, initiating the safety net save, and dedicated self-reflection/journaling sessions. The goal is to maximize the remaining days of January and set a powerful momentum for the rest of the year.",
+  "weekly_breakdown": [
+    {
+      "week": 1,
+      "focus": "Foundation Setting and Initial Journaling Dive",
+      "goals": [
+        "Complete 3 Push-up sessions (Initial assessment and form practice)",
+        "Secure the first dedicated saving installment towards safety net (500gh goal)",
+        "Identify and set up the development environment for Go Microservices exploration",
+        "Establish the daily habit of focused journaling about life and things"
+      ],
+      "daily_tasks": {
+        "Monday": [
+          {
+            "task_description": "Yearly Resolution Kick-off: Push-up assessment and initial set (3 sets of max reps + 5 mins stretching)",
+            "focus_area": "health",
+            "start_time": "2026-01-26T18:00:00",
+            "end_time": "2026-01-26T19:00:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Evening slot for physical activity before mandatory meeting."
+          },
+          {
+            "task_description": "Financial Planning: Calculate required weekly/bi-weekly deposits for the 500gh safety net goal (initial planning session)",
+            "focus_area": "finance",
+            "start_time": "2026-01-26T09:00:00",
+            "end_time": "2026-01-26T10:30:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Morning clarity for financial analysis, supporting yearly resolution."
+          },
+          {
+            "task_description": "Daily Journaling & Self Reflection: Introduction—Define 'Life and Things' topics and structure for the week's entries (Minimum 45 minutes writing)",
+            "focus_area": "personal",
+            "start_time": "2026-01-26T19:30:00",
+            "end_time": "2026-01-26T20:30:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Dedicated personal time before the evening meeting."
+          }
+        ],
+        "Tuesday": [
+          {
+            "task_description": "Learning Resolution: Set up Go environment (installation, VS Code setup, basic 'Hello World' project) for microservices prep",
+            "focus_area": "learning",
+            "start_time": "2026-01-27T09:00:00",
+            "end_time": "2026-01-27T12:00:00",
+            "difficulty_level": "advanced",
+            "scheduling_reason": "Large, focused block for technical setup."
+          },
+          {
+            "task_description": "Journal Entry 1: Current professional challenges and potential growth vectors ('Things' focus)",
+            "focus_area": "personal",
+            "start_time": "2026-01-27T18:00:00",
+            "end_time": "2026-01-27T19:00:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Review and reflection time after the core workday."
+          }
+        ],
+        "Wednesday": [
+          {
+            "task_description": "Learning Resolution: Deep dive into microservices foundational concepts (vs Monolith, service communication basics). Read two introductory articles.",
+            "focus_area": "learning",
+            "start_time": "2026-01-28T09:00:00",
+            "end_time": "2026-01-28T12:00:00",
+            "difficulty_level": "advanced",
+            "scheduling_reason": "Focused learning session."
+          },
+          {
+            "task_description": "Health Resolution: Push-up Session 2 (Increase sets or reps slightly based on Monday's assessment + 10 mins form critique via mirror/video)",
+            "focus_area": "health",
+            "start_time": "2026-01-28T18:00:00",
+            "end_time": "2026-01-28T19:00:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Mid-week physical check-in."
+          }
+        ],
+        "Thursday": [
+          {
+            "task_description": "Finance Resolution: Transfer the first weekly/bi-weekly target amount towards the 500gh safety net. Log transaction in tracking sheet.",
+            "focus_area": "finance",
+            "start_time": "2026-01-29T10:00:00",
+            "end_time": "2026-01-29T11:00:00",
+            "difficulty_level": "simple",
+            "scheduling_reason": "Executing the financial commitment planned earlier."
+          },
+          {
+            "task_description": "Self Reflection: Journal Entry 2 – Analyze current stressors and design one actionable coping strategy ('Life' focus)",
+            "focus_area": "personal",
+            "start_time": "2026-01-29T19:00:00",
+            "end_time": "2026-01-29T20:00:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Evening reflection."
+          }
+        ],
+        "Friday": [
+          {
+            "task_description": "Learning Resolution: Identify and select a simple practical project/tutorial (e.g., a simple user service) to implement the 'Hello World' microservice in Go. Outline steps.",
+            "focus_area": "learning",
+            "start_time": "2026-01-30T09:00:00",
+            "end_time": "2026-01-30T13:00:00",
+            "difficulty_level": "advanced",
+            "scheduling_reason": "Ambitious block for conceptual design and planning."
+          },
+          {
+            "task_description": "Health/Personal Check-in: Review consistency of push-ups and journaling this week. Plan adjustment for Week 2.",
+            "focus_area": "health",
+            "start_time": "2026-01-30T17:00:00",
+            "end_time": "2026-01-30T18:00:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "End-of-week review."
+          }
+        ],
+        "Saturday": [
+          {
+            "task_description": "Health Resolution: Push-up Session 3 (Extended duration, focusing particularly on full range of motion and core engagement.)",
+            "focus_area": "health",
+            "start_time": "2026-01-31T10:00:00",
+            "end_time": "2026-01-31T11:30:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Mixed weekend activity, dedicated morning time for physical goals."
+          },
+          {
+            "task_description": "Self Reflection: Journal Entry 3 (Weekly Summary)—Reflect on the successful steps taken this week and one unresolved interpersonal 'thing'.",
+            "focus_area": "personal",
+            "start_time": "2026-01-31T19:00:00",
+            "end_time": "2026-01-31T20:30:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Relaxed weekend reflection."
+          }
+        ],
+        "Sunday": [
+          {
+            "task_description": "Leisure Reading/Prep: Spend time reviewing resources for next week's Go Microservices implementation phase.",
+            "focus_area": "learning",
+            "start_time": "2026-02-01T14:00:00",
+            "end_time": "2026-02-01T16:00:00",
+            "difficulty_level": "simple",
+            "scheduling_reason": "Light prep for the coming ambitious week."
+          }
+        ]
+      }
+    },
+    {
+      "week": 2,
+      "focus": "Microservice Implementation and Health Progression",
+      "goals": [
+        "Complete 3 Push-up sessions, increasing volume by 10%",
+        "Write and deploy the basic 'Hello World' Go microservice structure",
+        "Reflect deeply on two key personal decisions using structured journaling",
+        "Maintain current financial savings pace towards 500gh"
+      ],
+      "daily_tasks": {
+        "Monday": [
+          {
+            "task_description": "Health Resolution: Push-up Session 4 (Increased volume, focus on controlled execution)",
+            "focus_area": "health",
+            "start_time": "2026-02-02T18:00:00",
+            "end_time": "2026-02-02T19:00:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Physical activity before the evening commitment."
+          },
+          {
+            "task_description": "Learning Resolution: Begin implementation of the initial Go microservice (setting up routing and basic structure/endpoints).",
+            "focus_area": "learning",
+            "start_time": "2026-02-02T09:00:00",
+            "end_time": "2026-02-02T13:00:00",
+            "difficulty_level": "advanced",
+            "scheduling_reason": "Ambitious block for coding start."
+          },
+          {
+            "task_description": "Journal Entry 4: Self Reflection on recent interactions – analyze communication patterns ('Life' focus)",
+            "focus_area": "personal",
+            "start_time": "2026-02-02T19:30:00",
+            "end_time": "2026-02-02T20:30:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Dedicated reflection time."
+          }
+        ],
+        "Tuesday": [
+          {
+            "task_description": "Learning Resolution: Continue Go microservice implementation (handling basic request input and simple internal logic). Debugging session.",
+            "focus_area": "learning",
+            "start_time": "2026-02-03T09:00:00",
+            "end_time": "2026-02-03T13:00:00",
+            "difficulty_level": "advanced",
+            "scheduling_reason": "Deep focused coding block."
+          },
+          {
+            "task_description": "Finance Resolution: Mid-week check on income/expense tracking to ensure safety net contribution remains viable.",
+            "focus_area": "finance",
+            "start_time": "2026-02-03T17:00:00",
+            "end_time": "2026-02-03T18:00:00",
+            "difficulty_level": "simple",
+            "scheduling_reason": "Quick review to ensure savings momentum."
+          }
+        ],
+        "Wednesday": [
+          {
+            "task_description": "Learning Resolution: Complete and test the initial 'Hello World' type microservice (Unit testing basics/Postman verification).",
+            "focus_area": "learning",
+            "start_time": "2026-02-04T09:00:00",
+            "end_time": "2026-02-04T12:00:00",
+            "difficulty_level": "advanced",
+            "scheduling_reason": "Finalizing the weekly learning objective."
+          },
+          {
+            "task_description": "Health Resolution: Push-up Session 5 (Focus on explosive power in the push-phase)",
+            "focus_area": "health",
+            "start_time": "2026-02-04T18:00:00",
+            "end_time": "2026-02-04T19:00:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Physical session."
+          }
+        ],
+        "Thursday": [
+          {
+            "task_description": "Finance Resolution: Transfer the second scheduled contribution to the 500gh safety net fund.",
+            "focus_area": "finance",
+            "start_time": "2026-02-05T10:00:00",
+            "end_time": "2026-02-05T11:00:00",
+            "difficulty_level": "simple",
+            "scheduling_reason": "Executing financial commitment."
+          },
+          {
+            "task_description": "Self Reflection: Journal Entry 5 – Deep dive into career visualization for the next 12 months ('Things' focus).",
+            "focus_area": "personal",
+            "start_time": "2026-02-05T19:00:00",
+            "end_time": "2026-02-05T20:00:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Evening strategic self-reflection."
+          }
+        ],
+        "Friday": [
+          {
+            "task_description": "Learning Resolution Review: Document lessons learned from the first Go Microservice project. Research integration patterns for Week 3.",
+            "focus_area": "learning",
+            "start_time": "2026-02-06T09:00:00",
+            "end_time": "2026-02-06T12:00:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Documentation and future planning."
+          },
+          {
+            "task_description": "Weekly Health/Finance Audit: Verify 2/8 finance sessions completed; 6/12 health sessions completed (combined Week 1 & 2 progress).",
+            "focus_area": "health",
+            "start_time": "2026-02-06T17:00:00",
+            "end_time": "2026-02-06T18:00:00",
+            "difficulty_level": "simple",
+            "scheduling_reason": "End-of-week tracking."
+          }
+        ],
+        "Saturday": [
+          {
+            "task_description": "Health Resolution: Push-up Session 6 (Full strength workout, focusing on achieving the target sets/reps planned during the week)",
+            "focus_area": "health",
+            "start_time": "2026-02-07T10:00:00",
+            "end_time": "2026-02-07T11:30:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Weekend physical routine."
+          },
+          {
+            "task_description": "Self Reflection: Journal Entry 6 (Open Format)—Free-flowing writing on any emergent thought related to 'Life and Things'.",
+            "focus_area": "personal",
+            "start_time": "2026-02-07T19:00:00",
+            "end_time": "2026-02-07T20:30:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Relaxed personal time."
+          }
+        ],
+        "Sunday": [
+          {
+            "task_description": "Prepare for Week 3 Learning: Research recommended databases or message queues (e.g., Redis, Kafka) for microservice communication.",
+            "focus_area": "learning",
+            "start_time": "2026-02-08T14:00:00",
+            "end_time": "2026-02-08T16:00:00",
+            "difficulty_level": "moderate",
+            "scheduling_reason": "Advance planning for the next technical phase."
+          }
+        ]
+      }
+    }
+  ]
+}
+```

--- a/apps/native/hooks/usePreferences.ts
+++ b/apps/native/hooks/usePreferences.ts
@@ -17,6 +17,14 @@ type FixedCommitmentsJson = {
   }>;
 };
 
+type ResolutionsJson = {
+  resolutions: Array<{
+    title: string;
+    category: string;
+    targetCount: number;
+  }>;
+};
+
 export type UpdatePreferencesInput = {
   coachName?: string;
   coachTone?: CoachTone;
@@ -27,6 +35,7 @@ export type UpdatePreferencesInput = {
   weekendPreference?: "Work" | "Rest" | "Mixed";
   preferredTaskDuration?: number;
   fixedCommitmentsJson?: FixedCommitmentsJson;
+  resolutionsJson?: ResolutionsJson;
 };
 
 export function useHelloPreference() {

--- a/apps/native/hooks/usePreferences.ts
+++ b/apps/native/hooks/usePreferences.ts
@@ -17,14 +17,6 @@ type FixedCommitmentsJson = {
   }>;
 };
 
-type ResolutionsJson = {
-  resolutions: Array<{
-    title: string;
-    category: string;
-    targetCount: number;
-  }>;
-};
-
 export type UpdatePreferencesInput = {
   coachName?: string;
   coachTone?: CoachTone;
@@ -32,8 +24,6 @@ export type UpdatePreferencesInput = {
   workingHoursEnd?: string;
   defaultFocusArea?: string;
   taskComplexity?: "Simple" | "Balanced" | "Ambitious";
-  focusAreas?: string;
-  resolutionsJson?: ResolutionsJson;
   weekendPreference?: "Work" | "Rest" | "Mixed";
   preferredTaskDuration?: number;
   fixedCommitmentsJson?: FixedCommitmentsJson;

--- a/apps/native/storage/chatStore.ts
+++ b/apps/native/storage/chatStore.ts
@@ -23,9 +23,17 @@ export type Conversation = {
   lastMessagePreview?: string;
 };
 
+export type MonitorSettings = {
+  tone: string;
+  depth: string;
+  format: string;
+};
+
 const KEY_CONVERSATIONS = "conversations:v1";
 const KEY_LAST_CONVERSATION = "conversations:last:v1";
+const KEY_MONITOR_DEFAULT = "monitor-settings:default:v1";
 const convKey = (conversationId: string) => `messages:v1:${conversationId}`;
+const convMonitorKey = (conversationId: string) => `monitor-settings:conversation:v1:${conversationId}`;
 
 function safeParse<T>(value: string | undefined): T | null {
   if (!value) return null;
@@ -128,4 +136,20 @@ export function setLastConversationId(conversationId: string) {
 
 export function getLastConversationId(): string | null {
   return storage.getString(KEY_LAST_CONVERSATION) ?? null;
+}
+
+export function getDefaultMonitorSettings(): MonitorSettings | null {
+  return safeParse<MonitorSettings>(storage.getString(KEY_MONITOR_DEFAULT));
+}
+
+export function setDefaultMonitorSettings(settings: MonitorSettings) {
+  storage.set(KEY_MONITOR_DEFAULT, JSON.stringify(settings));
+}
+
+export function getConversationMonitorSettings(conversationId: string): MonitorSettings | null {
+  return safeParse<MonitorSettings>(storage.getString(convMonitorKey(conversationId)));
+}
+
+export function setConversationMonitorSettings(conversationId: string, settings: MonitorSettings) {
+  storage.set(convMonitorKey(conversationId), JSON.stringify(settings));
 }

--- a/apps/native/storage/chatStore.ts
+++ b/apps/native/storage/chatStore.ts
@@ -23,9 +23,18 @@ export type Conversation = {
   lastMessagePreview?: string;
 };
 
+export type MonitorSettings = {
+  tone: string;
+  depth: string;
+  format: string;
+};
+
 const KEY_CONVERSATIONS = "conversations:v1";
 const KEY_LAST_CONVERSATION = "conversations:last:v1";
+const KEY_MONITOR_DEFAULT = "monitor-settings:default:v1";
 const convKey = (conversationId: string) => `messages:v1:${conversationId}`;
+const convMonitorKey = (conversationId: string) =>
+  `monitor-settings:conversation:v1:${conversationId}`;
 
 function safeParse<T>(value: string | undefined): T | null {
   if (!value) return null;
@@ -128,4 +137,20 @@ export function setLastConversationId(conversationId: string) {
 
 export function getLastConversationId(): string | null {
   return storage.getString(KEY_LAST_CONVERSATION) ?? null;
+}
+
+export function getDefaultMonitorSettings(): MonitorSettings | null {
+  return safeParse<MonitorSettings>(storage.getString(KEY_MONITOR_DEFAULT));
+}
+
+export function setDefaultMonitorSettings(settings: MonitorSettings) {
+  storage.set(KEY_MONITOR_DEFAULT, JSON.stringify(settings));
+}
+
+export function getConversationMonitorSettings(conversationId: string): MonitorSettings | null {
+  return safeParse<MonitorSettings>(storage.getString(convMonitorKey(conversationId)));
+}
+
+export function setConversationMonitorSettings(conversationId: string, settings: MonitorSettings) {
+  storage.set(convMonitorKey(conversationId), JSON.stringify(settings));
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -3,17 +3,27 @@ import { createContext } from "@monthly-zen/api/context";
 import { appRouter } from "@monthly-zen/api/routers/index";
 import { streamChatCompletion, type OpenRouterMessage } from "@monthly-zen/api/lib/openrouter";
 import { auth } from "@monthly-zen/auth";
+import * as db from "@monthly-zen/db";
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
 import { onError } from "@orpc/server";
 import { RPCHandler } from "@orpc/server/fetch";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { Hono } from "hono";
+import type { Context as HonoContext } from "hono";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { stream } from "hono/streaming";
 
 const app = new Hono();
+
+const DEFAULT_SYSTEM_PROMPT =
+  "You are Monthly Zen, a planning assistant. Create clear month plans, focus maps, and next steps.";
+
+async function requireUserId(c: HonoContext) {
+  const session = await auth.api.getSession({ headers: c.req.raw.headers });
+  return session?.user?.id ?? null;
+}
 
 app.use(logger());
 app.use(
@@ -30,6 +40,208 @@ app.on(["POST", "GET"], "/api/auth/*", (c) => auth.handler(c.req.raw));
 
 app.get("/api/health", (c) => {
   return c.json({ ok: true });
+});
+
+app.post("/api/conversations", async (c) => {
+  const userId = await requireUserId(c);
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const body = (await c.req.json().catch(() => ({}))) as { id?: string; title?: string };
+  const id = typeof body.id === "string" ? body.id : undefined;
+  const title = typeof body.title === "string" ? body.title : null;
+
+  const [created] = await db.db
+    .insert(db.conversations)
+    .values({
+      ...(id ? { id } : {}),
+      userId,
+      title,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  const conversation = created ?? (await db.getConversationById(userId, id ?? ""));
+
+  if (!conversation) {
+    return c.json({ error: "Failed to create conversation" }, 500);
+  }
+
+  return c.json({ id: conversation.id });
+});
+
+app.get("/api/conversations", async (c) => {
+  const userId = await requireUserId(c);
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const conversations = await db.listConversations(userId);
+  return c.json({ conversations });
+});
+
+app.get("/api/conversations/:id/messages", async (c) => {
+  const userId = await requireUserId(c);
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const conversationId = c.req.param("id");
+  const messages = await db.listMessages(userId, conversationId);
+  return c.json({ messages });
+});
+
+app.post("/api/conversations/:id/stream", async (c) => {
+  const userId = await requireUserId(c);
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const conversationId = c.req.param("id");
+  const conversation = await db.getConversationById(userId, conversationId);
+  if (!conversation) return c.json({ error: "Conversation not found" }, 404);
+
+  const body = (await c.req.json().catch(() => ({}))) as {
+    message?: string;
+    temperature?: number;
+    maxTokens?: number;
+  };
+
+  const question = typeof body.message === "string" ? body.message.trim() : "";
+  if (!question) return c.json({ error: "message is required" }, 400);
+
+  const systemPrompt = process.env.OPENROUTER_SYSTEM_PROMPT ?? DEFAULT_SYSTEM_PROMPT;
+  const model = process.env.OPENROUTER_MODEL ?? "google/gemini-2.5-flash";
+
+  // Persist user + assistant placeholder
+  await db.addMessage({ conversationId, role: "user", content: question, status: "final" });
+  const assistant = await db.addMessage({
+    conversationId,
+    role: "assistant",
+    content: "",
+    status: "streaming",
+    meta: { model },
+  });
+
+  if (!assistant) {
+    return c.json({ error: "Failed to create assistant message" }, 500);
+  }
+
+  await db.updateConversation(userId, conversationId, {
+    lastMessagePreview: question.slice(0, 120),
+  });
+
+  const history = await db.listMessages(userId, conversationId, 40);
+  const nonSystemMessages: OpenRouterMessage[] = history
+    .filter((m) => m.role !== "system")
+    .filter((m) => !(m.id === assistant.id))
+    .map((m) => ({
+      role: m.role as "user" | "assistant",
+      content: m.content,
+    }));
+
+  const messages: OpenRouterMessage[] = [
+    { role: "system", content: systemPrompt },
+    ...nonSystemMessages,
+  ];
+
+  let streamResponse: Awaited<ReturnType<typeof streamChatCompletion>>;
+  try {
+    streamResponse = await streamChatCompletion({
+      model,
+      messages,
+      temperature: body.temperature,
+      maxTokens: body.maxTokens,
+      includeUsage: true,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to start stream";
+    await db.updateMessage(conversationId, assistant.id, {
+      status: "error",
+      content: `Error: ${message}`,
+    });
+    return c.json({ error: message }, 500);
+  }
+
+  c.header("Content-Type", "text/event-stream; charset=utf-8");
+  c.header("Cache-Control", "no-cache, no-transform");
+  c.header("Connection", "keep-alive");
+  c.header("X-Accel-Buffering", "no");
+  c.header("Content-Encoding", "identity");
+
+  return stream(c, async (streamWriter) => {
+    let buffer = "";
+    let latestUsage: unknown = null;
+    let doneSent = false;
+    let scheduled: ReturnType<typeof setTimeout> | null = null;
+
+    const keepalive = setInterval(() => {
+      streamWriter.write(": ping\n\n").catch(() => {});
+    }, 15000);
+
+    const scheduleFlush = () => {
+      if (scheduled) return;
+      scheduled = setTimeout(() => {
+        scheduled = null;
+        void db.updateMessage(conversationId, assistant.id, { content: buffer });
+      }, 500);
+    };
+
+    try {
+      for await (const chunk of streamResponse) {
+        if (chunk.error?.message) {
+          await streamWriter.write(
+            `data: ${JSON.stringify({ type: "error", message: chunk.error.message })}\n\n`,
+          );
+          buffer = `Error: ${chunk.error.message}`;
+          await db.updateMessage(conversationId, assistant.id, {
+            status: "error",
+            content: buffer,
+          });
+          doneSent = true;
+          break;
+        }
+
+        const choice = chunk.choices?.[0];
+        const delta = choice?.delta?.content;
+        if (delta) {
+          buffer += delta;
+          await streamWriter.write(`data: ${JSON.stringify({ type: "delta", text: delta })}\n\n`);
+          scheduleFlush();
+        }
+
+        if (chunk.usage) {
+          latestUsage = chunk.usage;
+        }
+
+        const finishReason = choice?.finish_reason;
+        if (finishReason && finishReason !== "error") {
+          await streamWriter.write(`data: ${JSON.stringify({ type: "done", finishReason })}\n\n`);
+          doneSent = true;
+          break;
+        }
+      }
+
+      if (!doneSent) {
+        await streamWriter.write(`data: ${JSON.stringify({ type: "done" })}\n\n`);
+      }
+
+      await db.updateMessage(conversationId, assistant.id, {
+        status: "final",
+        content: buffer,
+        meta: latestUsage ? { model, usage: latestUsage } : { model },
+      });
+
+      await db.updateConversation(userId, conversationId, {
+        lastMessagePreview: (buffer || question).slice(0, 120),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Stream failed";
+      await streamWriter.write(`data: ${JSON.stringify({ type: "error", message })}\n\n`);
+      await db.updateMessage(conversationId, assistant.id, {
+        status: "error",
+        content: buffer || `Error: ${message}`,
+      });
+    } finally {
+      clearInterval(keepalive);
+      if (scheduled) clearTimeout(scheduled);
+    }
+  });
 });
 
 app.post("/api/v2/openrouter", async (c) => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -30,8 +30,8 @@ app.use(
   "/*",
   cors({
     origin: process.env.CORS_ORIGIN || "",
-    allowMethods: ["GET", "POST", "OPTIONS"],
-    allowHeaders: ["Content-Type", "Authorization"],
+    allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+    allowHeaders: ["Content-Type", "Authorization", "Cookie"],
     credentials: true,
   }),
 );
@@ -86,6 +86,17 @@ app.get("/api/conversations/:id/messages", async (c) => {
   const conversationId = c.req.param("id");
   const messages = await db.listMessages(userId, conversationId);
   return c.json({ messages });
+});
+
+app.delete("/api/conversations/:id", async (c) => {
+  const userId = await requireUserId(c);
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const conversationId = c.req.param("id");
+  const deleted = await db.deleteConversation(userId, conversationId);
+  if (!deleted) return c.json({ error: "Conversation not found" }, 404);
+
+  return c.json({ success: true });
 });
 
 app.post("/api/conversations/:id/stream", async (c) => {

--- a/packages/db/src/queries/conversations.ts
+++ b/packages/db/src/queries/conversations.ts
@@ -122,3 +122,11 @@ export async function getLatestAssistantMessage(userId: string, conversationId: 
 
   return row ?? null;
 }
+
+export async function deleteConversation(userId: string, conversationId: string) {
+  const result = await db
+    .delete(conversations)
+    .where(and(eq(conversations.id, conversationId), eq(conversations.userId, userId)));
+
+  return (result.rowCount ?? 0) > 0;
+}

--- a/packages/db/src/queries/conversations.ts
+++ b/packages/db/src/queries/conversations.ts
@@ -1,0 +1,124 @@
+import { and, desc, eq } from "drizzle-orm";
+
+import { db } from "../index";
+import { conversations, messages } from "../schema";
+
+export type ConversationRow = typeof conversations.$inferSelect;
+export type MessageRow = typeof messages.$inferSelect;
+
+export async function createConversation(userId: string, title?: string | null) {
+  const [row] = await db
+    .insert(conversations)
+    .values({
+      userId,
+      title: title ?? null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .returning();
+
+  return row;
+}
+
+export async function listConversations(userId: string, limit: number = 50) {
+  return await db
+    .select()
+    .from(conversations)
+    .where(eq(conversations.userId, userId))
+    .orderBy(desc(conversations.updatedAt))
+    .limit(limit);
+}
+
+export async function getConversationById(userId: string, conversationId: string) {
+  const [row] = await db
+    .select()
+    .from(conversations)
+    .where(and(eq(conversations.id, conversationId), eq(conversations.userId, userId)))
+    .limit(1);
+
+  return row;
+}
+
+export async function addMessage(input: {
+  conversationId: string;
+  role: "system" | "user" | "assistant";
+  content: string;
+  status?: "streaming" | "final" | "error";
+  meta?: Record<string, unknown> | null;
+}) {
+  const now = new Date();
+  const [row] = await db
+    .insert(messages)
+    .values({
+      conversationId: input.conversationId,
+      role: input.role,
+      content: input.content,
+      status: input.status ?? "final",
+      meta: input.meta ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+
+  return row;
+}
+
+export async function updateMessage(
+  conversationId: string,
+  messageId: string,
+  patch: Partial<Pick<MessageRow, "content" | "status" | "meta">>,
+) {
+  const [row] = await db
+    .update(messages)
+    .set({
+      ...patch,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(messages.id, messageId), eq(messages.conversationId, conversationId)))
+    .returning();
+
+  return row;
+}
+
+export async function updateConversation(
+  userId: string,
+  conversationId: string,
+  patch: Partial<Pick<ConversationRow, "title" | "lastMessagePreview">>,
+) {
+  const [row] = await db
+    .update(conversations)
+    .set({
+      ...patch,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(conversations.id, conversationId), eq(conversations.userId, userId)))
+    .returning();
+
+  return row;
+}
+
+export async function listMessages(userId: string, conversationId: string, limit: number = 200) {
+  const conversation = await getConversationById(userId, conversationId);
+  if (!conversation) return [];
+
+  return await db
+    .select()
+    .from(messages)
+    .where(eq(messages.conversationId, conversationId))
+    .orderBy(messages.createdAt)
+    .limit(limit);
+}
+
+export async function getLatestAssistantMessage(userId: string, conversationId: string) {
+  const conversation = await getConversationById(userId, conversationId);
+  if (!conversation) return null;
+
+  const [row] = await db
+    .select()
+    .from(messages)
+    .where(and(eq(messages.conversationId, conversationId), eq(messages.role, "assistant")))
+    .orderBy(desc(messages.createdAt))
+    .limit(1);
+
+  return row ?? null;
+}

--- a/packages/db/src/queries/index.ts
+++ b/packages/db/src/queries/index.ts
@@ -14,3 +14,4 @@ export * from "./pattern-detection";
 export * from "./yearly-resolutions";
 export * from "./user-preferences";
 export * from "./user";
+export * from "./conversations";

--- a/packages/db/src/queries/plan-generation-jobs.ts
+++ b/packages/db/src/queries/plan-generation-jobs.ts
@@ -21,6 +21,7 @@ export async function updatePlanGenerationJob(
     status: "pending" | "running" | "completed" | "failed";
     responseText: string | null;
     planId: number | null;
+    conversationId: string | null;
     errorMessage: string | null;
   }>,
 ) {

--- a/packages/db/src/schema/conversations.ts
+++ b/packages/db/src/schema/conversations.ts
@@ -1,0 +1,28 @@
+import { relations } from "drizzle-orm";
+import { index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+import { user } from "./auth";
+import { messages } from "./messages";
+
+export const conversations = pgTable(
+  "conversations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: text("user_id")
+      .references(() => user.id)
+      .notNull(),
+    title: text("title"),
+    lastMessagePreview: text("last_message_preview"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [index("conversations_user_updated_idx").on(table.userId, table.updatedAt)],
+);
+
+export const conversationsRelations = relations(conversations, ({ one, many }) => ({
+  user: one(user, {
+    fields: [conversations.userId],
+    references: [user.id],
+  }),
+  messages: many(messages),
+}));

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -5,6 +5,8 @@ export * from "./monthly-plans";
 export * from "./plan-tasks";
 export * from "./yearly-resolutions";
 export * from "./plan-generation-jobs";
+export * from "./conversations";
+export * from "./messages";
 export * from "./generation-quota";
 export * from "./quota-history";
 export * from "./ai-request-logs";

--- a/packages/db/src/schema/messages.ts
+++ b/packages/db/src/schema/messages.ts
@@ -1,0 +1,30 @@
+import { relations } from "drizzle-orm";
+import { index, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+import { conversations } from "./conversations";
+
+export const messages = pgTable(
+  "messages",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    conversationId: uuid("conversation_id")
+      .references(() => conversations.id, { onDelete: "cascade" })
+      .notNull(),
+    role: text("role", { enum: ["system", "user", "assistant"] }).notNull(),
+    content: text("content").notNull().default(""),
+    status: text("status", { enum: ["streaming", "final", "error"] })
+      .notNull()
+      .default("final"),
+    meta: jsonb("meta").$type<Record<string, unknown> | null>(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [index("messages_conversation_created_idx").on(table.conversationId, table.createdAt)],
+);
+
+export const messagesRelations = relations(messages, ({ one }) => ({
+  conversation: one(conversations, {
+    fields: [messages.conversationId],
+    references: [conversations.id],
+  }),
+}));

--- a/packages/db/src/schema/plan-generation-jobs.ts
+++ b/packages/db/src/schema/plan-generation-jobs.ts
@@ -1,6 +1,7 @@
-import { pgTable, serial, text, timestamp, integer, jsonb } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, timestamp, integer, jsonb, uuid } from "drizzle-orm/pg-core";
 import { user } from "./auth";
 import { monthlyPlans } from "./monthly-plans";
+import { conversations } from "./conversations";
 
 export type PlanGenerationStatus = "pending" | "running" | "completed" | "failed";
 
@@ -15,6 +16,7 @@ export const planGenerationJobs = pgTable("plan_generation_jobs", {
   requestPayload: jsonb("request_payload").notNull(),
   responseText: text("response_text"),
   planId: integer("plan_id").references(() => monthlyPlans.id),
+  conversationId: uuid("conversation_id").references(() => conversations.id),
   errorMessage: text("error_message"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/plans/006-openrouter-tool-calling-typescript.md
+++ b/plans/006-openrouter-tool-calling-typescript.md
@@ -1,0 +1,22 @@
+# OpenRouter Responses Tool Calling (TypeScript)
+
+## Plan
+
+- Confirm runtime target: Node.js server vs browser (API key handling differs); default to Node.js.
+- Define tool schemas using OpenAI function calling format (`type`, `name`, `description`, `parameters`, optional `strict`).
+- Build a `fetch` wrapper for `POST https://openrouter.ai/api/v1/responses` with headers and JSON body.
+- Implement non-streaming flow:
+  - Send initial `input` messages with `tools` and `tool_choice`.
+  - Parse `output` items and detect `type: "function_call"`.
+  - Execute tool handler(s) and build `function_call_output` items.
+  - Send follow-up request including `function_call` and `function_call_output` items to produce final assistant output.
+- Optional streaming flow:
+  - Set `stream: true`, parse `response.output_item.added` and `response.function_call_arguments.done` events.
+  - Trigger tool execution when arguments complete and continue response handling.
+- Add error handling:
+  - Missing outputs, invalid JSON in arguments, unknown tool name, tool execution failures.
+  - Return a structured error tool output when a tool fails.
+- Deliver a compact end-to-end TypeScript example:
+  - Tool definition (e.g., `calculate`).
+  - Tool dispatcher map.
+  - Request → tool execution → follow-up response.


### PR DESCRIPTION
### Motivation
- Allow users to tweak the streaming monitor (tone/depth/format) per conversation instead of always relying on a global preference.
- Persist conversation-specific monitor settings and fall back to a user default so each conversation can have its own AI tuning.

### Description
- Persist monitor settings: added `MonitorSettings` type and storage helpers `getDefaultMonitorSettings`, `setDefaultMonitorSettings`, `getConversationMonitorSettings`, and `setConversationMonitorSettings` in `apps/native/storage/chatStore.ts` to store defaults and per-conversation values.
- UI + editor: added a bottom-sheet editor and UI to `apps/native/app/test/ai-stream.tsx` to view and edit `Tone`, `Depth`, and `Format`, including a `Save as default` action, settings button, and monitor stats display.
- Prompt injection: the monitor values are applied to the system prompt used for streaming by replacing the static `SYSTEM_PROMPT` with a computed `systemPrompt` that includes the selected `tone`, `depth`, and `format` when building messages.
- Wiring and UX: added `@gorhom/bottom-sheet` components, settings state (`tone`, `depth`, `format`), handlers to save per-conversation and default settings, and small UX touches (`Haptics` feedback, settings snap point).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69770df412cc8321b9e957438fecf990)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation tuning UI with configurable Monitor settings (Tone, Depth, Format), save-per-conversation and save-as-default flows, and a Draft review screen.
* **Refactor**
  * Chat and conversations moved to server-backed flows with persisted conversations, messages, and server-streamed assistant responses (SSE).
* **UI/UX**
  * Tuning header/button, draft actions, toast notifications, and minor visual tweaks.
* **Data**
  * New sample response asset with a two-week plan included.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->